### PR TITLE
feat: 기록장(Note) 뷰 추가 + 컬러 에셋 추가 + 하프모달 패키지 추가

### DIFF
--- a/GilCat/GilCat.xcodeproj/project.pbxproj
+++ b/GilCat/GilCat.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		5800E59C2851908D002F6A75 /* PlaceholderTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5800E59B2851908D002F6A75 /* PlaceholderTextField.swift */; };
 		5800E59E285191F3002F6A75 /* BarColorNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5800E59D285191F3002F6A75 /* BarColorNavigation.swift */; };
+		58790F6828558F3C00B20552 /* PartialSheet in Frameworks */ = {isa = PBXBuildFile; productRef = 58790F6728558F3C00B20552 /* PartialSheet */; };
+		58790F6C28558FD800B20552 /* NoteProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58790F6B28558FD800B20552 /* NoteProfileView.swift */; };
+		58790F6E28558FE300B20552 /* NoteFoodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58790F6D28558FE300B20552 /* NoteFoodView.swift */; };
+		58790F7028558FEE00B20552 /* NoteWaterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58790F6F28558FEE00B20552 /* NoteWaterView.swift */; };
 		58A2002B28520B5500C656DF /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A2002A28520B5500C656DF /* LoginView.swift */; };
 		58A2002D28520B6F00C656DF /* NoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A2002C28520B6F00C656DF /* NoteView.swift */; };
 		EF1DEE332849B795000268C7 /* GilCatApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1DEE322849B795000268C7 /* GilCatApp.swift */; };
@@ -36,6 +40,9 @@
 /* Begin PBXFileReference section */
 		5800E59B2851908D002F6A75 /* PlaceholderTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderTextField.swift; sourceTree = "<group>"; };
 		5800E59D285191F3002F6A75 /* BarColorNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarColorNavigation.swift; sourceTree = "<group>"; };
+		58790F6B28558FD800B20552 /* NoteProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteProfileView.swift; sourceTree = "<group>"; };
+		58790F6D28558FE300B20552 /* NoteFoodView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteFoodView.swift; sourceTree = "<group>"; };
+		58790F6F28558FEE00B20552 /* NoteWaterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWaterView.swift; sourceTree = "<group>"; };
 		58A2002A28520B5500C656DF /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		58A2002C28520B6F00C656DF /* NoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteView.swift; sourceTree = "<group>"; };
 		EF1DEE2F2849B795000268C7 /* GilCat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GilCat.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -57,6 +64,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				58790F6828558F3C00B20552 /* PartialSheet in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,6 +82,9 @@
 			isa = PBXGroup;
 			children = (
 				58A2002C28520B6F00C656DF /* NoteView.swift */,
+				58790F6B28558FD800B20552 /* NoteProfileView.swift */,
+				58790F6D28558FE300B20552 /* NoteFoodView.swift */,
+				58790F6F28558FEE00B20552 /* NoteWaterView.swift */,
 			);
 			path = Note;
 			sourceTree = "<group>";
@@ -238,6 +249,7 @@
 			);
 			name = GilCat;
 			packageProductDependencies = (
+				58790F6728558F3C00B20552 /* PartialSheet */,
 			);
 			productName = GilCat;
 			productReference = EF1DEE2F2849B795000268C7 /* GilCat.app */;
@@ -290,6 +302,7 @@
 			);
 			mainGroup = EF1DEE262849B795000268C7;
 			packageReferences = (
+				58790F6628558F3C00B20552 /* XCRemoteSwiftPackageReference "PartialSheet" */,
 			);
 			productRefGroup = EF1DEE302849B795000268C7 /* Products */;
 			projectDirPath = "";
@@ -353,8 +366,11 @@
 				58A2002B28520B5500C656DF /* LoginView.swift in Sources */,
 				EFA7B9432849EC48006671EF /* TestSupportView.swift in Sources */,
 				EFA7B9362849EB22006671EF /* ComponentsTestView.swift in Sources */,
+				58790F6E28558FE300B20552 /* NoteFoodView.swift in Sources */,
+				58790F7028558FEE00B20552 /* NoteWaterView.swift in Sources */,
 				58A2002D28520B6F00C656DF /* NoteView.swift in Sources */,
 				EFA7B93B2849EBB9006671EF /* ColorPallete.swift in Sources */,
+				58790F6C28558FD800B20552 /* NoteProfileView.swift in Sources */,
 				5800E59E285191F3002F6A75 /* BarColorNavigation.swift in Sources */,
 				EFA7B9382849EB5C006671EF /* TestExtension.swift in Sources */,
 			);
@@ -618,6 +634,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		58790F6628558F3C00B20552 /* XCRemoteSwiftPackageReference "PartialSheet" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/AndreaMiotto/PartialSheet.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		58790F6728558F3C00B20552 /* PartialSheet */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 58790F6628558F3C00B20552 /* XCRemoteSwiftPackageReference "PartialSheet" */;
+			productName = PartialSheet;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = EF1DEE272849B795000268C7 /* Project object */;
 }

--- a/GilCat/GilCat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GilCat/GilCat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "partialsheet",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AndreaMiotto/PartialSheet.git",
+      "state" : {
+        "revision" : "318f18bfabd2b2ddf785babd2e53bd593c00a254",
+        "version" : "3.1.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/GilCat/GilCat/Resources/Assets.xcassets/Morphic1.colorset/Contents.json
+++ b/GilCat/GilCat/Resources/Assets.xcassets/Morphic1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.584",
+          "green" : "0.494",
+          "red" : "0.420"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GilCat/GilCat/Resources/Assets.xcassets/Morphic2.colorset/Contents.json
+++ b/GilCat/GilCat/Resources/Assets.xcassets/Morphic2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.176",
+          "green" : "0.129",
+          "red" : "0.090"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GilCat/GilCat/Resources/Assets.xcassets/Morphic3.colorset/Contents.json
+++ b/GilCat/GilCat/Resources/Assets.xcassets/Morphic3.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.141",
+          "green" : "0.216",
+          "red" : "0.333"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GilCat/GilCat/Sources/Screen/Note/NoteFoodView.swift
+++ b/GilCat/GilCat/Sources/Screen/Note/NoteFoodView.swift
@@ -1,0 +1,20 @@
+//
+//  NoteFoodView.swift
+//  GilCat
+//
+//  Created by KYUBO A. SHIM on 2022/06/12.
+//
+
+import SwiftUI
+
+struct NoteFoodView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct NoteFoodView_Previews: PreviewProvider {
+    static var previews: some View {
+        NoteFoodView()
+    }
+}

--- a/GilCat/GilCat/Sources/Screen/Note/NoteProfileView.swift
+++ b/GilCat/GilCat/Sources/Screen/Note/NoteProfileView.swift
@@ -1,0 +1,20 @@
+//
+//  NoteProfileView.swift
+//  GilCat
+//
+//  Created by KYUBO A. SHIM on 2022/06/12.
+//
+
+import SwiftUI
+
+struct NoteProfileView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct NoteProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        NoteProfileView()
+    }
+}

--- a/GilCat/GilCat/Sources/Screen/Note/NoteView.swift
+++ b/GilCat/GilCat/Sources/Screen/Note/NoteView.swift
@@ -6,10 +6,342 @@
 //
 
 import SwiftUI
+import PartialSheet
 
 struct NoteView: View {
+    
+    // Dummy Datas
+    let healthList = ["피부에 문제가 있어보여요", "복부가 부었어요", "걸음걸이가 이상해보여요", "임신을 했어요", "털 상태가 좋지 못해요", "피가 나요", "토를 계속 해요"]
+    let memoList = ["오늘은 달이가 다른 고양이와 싸우고 온 것 같다. 덩치도 산만한 것이 싸움도 못하나 보다. 목덜미 주변에 피가 있는데 닦아 주지를 못한다. 아직 달이와 나의 거리는 3미터 내로 좁혀지지 않는다. 상처를 치료해주지 못해 답답.", "저 저 나쁜 놈이 있다. 덩치는 달이의 반도 못하는데, 얼마나 날렵해 보이는지... 달이가 생각보다 나이가 많은가 보다. 뚜드려 맞는 장면을 봤다. 어쩐지 평소보다 사료가 더 많이 남아있더라니... 달이가 하나도 먹지 못하고 저놈시키가 몇알 뺏어먹고 말았구나..."]
+    
+    init() {
+        Theme.navigationBarColors(background: .systemFill, titleColor: .white)
+    }
+    
+//    @Binding var hourEx: String
+    @Environment(\.presentationMode) var presentation
+    @State private var stickNumber = 0
+    @State private var checkProfile = false
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        
+        ZStack {
+            Color("Background")
+                .edgesIgnoringSafeArea(.all)
+            
+            ScrollView(.vertical, showsIndicators: false) {
+                    LazyVStack {
+                        // MARK: 프로필 사진
+                        Image("cat_gray_3")
+                            .resizable()
+                            .scaledToFit()
+                            .padding()
+                            .background(Color("DarkPanel"))
+                            .frame(width: 120, height: 120)
+                            .clipShape(RoundedRectangle(cornerRadius: 43, style: .continuous))
+                            .padding(.top, 10)
+
+                        // MARK: 이름
+                        ZStack {
+                            Image("twoLetter")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 80, height: 80, alignment: .center)
+                                .offset(y: 14)
+                                
+                            Text("나비")
+                                .font(.system(size: 40, weight: .heavy))
+                                .foregroundColor(.white)
+                        }
+                        .padding(.bottom, 10)
+                        .offset(y: -10)
+                        
+                        // MARK: 프로필 자세히 보기
+                        RoundedRectangle(cornerRadius: 36, style: .continuous)
+                            .foregroundColor(Color("Button"))
+                            .frame(width: 180, height: 44, alignment: .center)
+                            .shadow(color: Color("Morphic3").opacity(0.8), radius: 5, x: 5, y: 5)
+                            .shadow(color: Color("Morphic1").opacity(0.9), radius: 5, x: -5, y: -5)
+                            .overlay {
+                                Text("프로필 자세히 보기")
+                                    .font(.system(size: 15, weight: .heavy))
+                                    .foregroundColor(.white)
+                            }
+                            .onTapGesture {
+                                checkProfile.toggle()
+                            }
+                            .partialSheet(isPresented: $checkProfile,
+                                          iPhoneStyle: PSIphoneStyle(background: .solid(Color("Background")),
+                                                                     handleBarStyle: .none,
+                                                                     cover: .enabled(Color.black.opacity(0.5)),
+                                                                     cornerRadius: 24)) {
+                                NoteProfileView()
+                            }
+                            .padding(.bottom, 30)
+                        
+                        // MARK: 마지막 급식급수
+                        HStack(spacing: 24) {
+                            NavigationLink(destination: NoteFoodView()) {
+                                RoundedRectangle(cornerRadius: 40, style: .continuous)
+                                    .frame(width: 160, height: 230)
+                                    .foregroundColor(Color("DarkPanel").opacity(0.9))
+                                    .shadow(color: Color("Morphic2").opacity(0.8), radius: 5, x: 5, y: 5)
+                                    .shadow(color: Color("Morphic1").opacity(0.6), radius: 5, x: -5, y: -5)
+                                    .overlay {
+                                        VStack {
+                                        
+                                            Spacer()
+                                            
+                                            Text("마지막 급식")
+                                                .foregroundColor(.white)
+                                                .font(.system(size: 20, weight: .bold))
+                                                .offset(y: 10)
+                                                .padding()
+                                                
+                                            Image("foodBowl")
+                                                .resizable()
+                                                .scaledToFit()
+                                                .frame(width: 60, height: 60)
+                                            
+                                            Text("12:30")
+                                                .font(.system(size: 32, weight: .heavy))
+                                                .foregroundColor(Color("Button"))
+                                            
+                                            Spacer()
+                                            
+                                            Text("눌러서 갱신")
+                                                .font(.system(size: 14, weight: .light))
+                                                .foregroundColor(.gray)
+                                                .padding()
+                                                .padding(.bottom, 5)
+                                        }
+                                }
+                                    
+                            }
+                                
+                            NavigationLink(destination: NoteWaterView()) {
+                                RoundedRectangle(cornerRadius: 40, style: .continuous)
+                                    .frame(width: 160, height: 230)
+                                    .foregroundColor(Color("DarkPanel").opacity(0.9))
+                                    .shadow(color: Color("Morphic2").opacity(0.8), radius: 5, x: 5, y: 5)
+                                    .shadow(color: Color("Morphic1").opacity(0.6), radius: 5, x: -5, y: -5)
+                                    .overlay {
+                                        VStack {
+                                        
+                                            Spacer()
+                                            
+                                            Text("마지막 급수")
+                                                .foregroundColor(.white)
+                                                .font(.system(size: 20, weight: .bold))
+                                                .offset(y: 10)
+                                                .padding()
+                                                
+                                            Image("waterBowl")
+                                                .resizable()
+                                                .scaledToFit()
+                                                .frame(width: 60, height: 60)
+                                            
+                                            Text("19:30")
+                                                .font(.system(size: 32, weight: .heavy))
+                                                .foregroundColor(Color("Button"))
+                                            
+                                            Spacer()
+                                            
+                                            Text("눌러서 갱신")
+                                                .font(.system(size: 14, weight: .light))
+                                                .foregroundColor(.gray)
+                                                .padding()
+                                                .padding(.bottom, 5)
+
+                                        }
+                                }
+                            }
+                        }
+                        .padding()
+                        
+                        // MARK: 츄르 몇개?
+                        RoundedRectangle(cornerRadius: 30, style: .continuous)
+                            .frame(width: 340, height: 85)
+                            .foregroundColor(Color("DarkPanel").opacity(0.9))
+                            .shadow(color: Color("Morphic2").opacity(0.8), radius: 5, x: 5, y: 5)
+                            .shadow(color: Color("Morphic1").opacity(0.6), radius: 5, x: -5, y: -5)
+                            .overlay {
+                                HStack {
+                                    Text("츄르 몇개?")
+                                        .font(.system(size: 20, weight: .heavy))
+                                        .foregroundColor(.white)
+                                        .minimumScaleFactor(0.5)
+                                        .padding()
+                                    
+                                    Spacer()
+                                    
+                                    ZStack {
+                                        
+                                        if stickNumber == 0 {
+                                            Text("터치하면 추가됩니다.\n자정에 갱신됩니다.")
+                                                .font(.system(size: 16, weight: .light))
+                                                .foregroundColor(.white)
+                                                .opacity(0.8)
+                                                .padding(.horizontal, 10)
+                                                .onTapGesture {
+                                                    stickNumber += 1
+                                                }
+                                        } else if 0 < stickNumber && stickNumber < 6 {
+                                            HStack(spacing: 5) {
+                                                ForEach(0...stickNumber-1, id: \.self) { _ in
+                                                    Image("stick")
+                                                        .resizable()
+                                                        .scaledToFit()
+                                                        .frame(width: 30, height: 60)
+                                                }
+                                            }
+                                            .onTapGesture {
+                                                stickNumber += 1
+                                            }
+                                        } else {
+                                            HStack {
+                                                Spacer()
+                                                
+                                                Text("\(stickNumber)개")
+                                                    .font(.system(size: 24, weight: .heavy))
+                                                    .foregroundColor(.red)
+                                                
+                                                Spacer()
+                                                
+                                                Text("그..그만 주세요!")
+                                                    .font(.system(size: 14, weight: .heavy))
+                                                    .foregroundColor(.orange)
+                                            }
+                                            .onTapGesture {
+                                                stickNumber += 1
+                                            }
+                                            .padding()
+                                        }
+                                    }
+                                }
+                                .padding()
+                            }
+                            .padding(.bottom, 20)
+                        
+                        // MARK: 건강상태 섹션
+                        HStack {
+                            Text("건강 상태")
+                                .font(.system(size: 26, weight: .heavy))
+                                .foregroundColor(.white)
+                                .padding()
+                                .offset(x: 20)
+                            
+                            Spacer()
+                            
+                            Button {
+                                
+                            } label: {
+                                Image(systemName: "plus.circle")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 25, height: 25)
+                                    .foregroundColor(.white)
+                                    .opacity(0.6)
+                                    .padding()
+                            }
+                            .padding(.horizontal, 20)
+                        }
+                        
+                        // MARK: 건강상태 박스
+                        VStack {
+                            Spacer().frame(height: 24)
+                            
+                            ForEach(healthList, id: \.self) { comps in
+                                HStack {
+                                    Text("\(comps)")
+                                        .font(.system(size: 14, weight: .bold))
+                                        .foregroundColor(.white)
+                                        .padding()
+                                        .background(Color("Background").opacity(0.5))
+                                        .cornerRadius(24)
+                                    
+                                    Spacer()
+                                }
+                                .padding(.horizontal, 16)
+                            }
+                            Spacer().frame(height: 24)
+                        }
+                        .frame(width: 340)
+                        .background(Color("DarkPanel").opacity(0.8))
+                        .cornerRadius(30)
+                        .shadow(color: Color("Morphic2").opacity(0.8), radius: 4, x: 4, y: 4)
+                        .shadow(color: Color("Morphic1").opacity(0.6), radius: 4, x: -4, y: -4)
+                        .padding(.bottom, 20)
+                        
+                        // MARK: 개인 메모장 섹션
+                        HStack {
+                            Text("개인 메모장")
+                                .font(.system(size: 26, weight: .heavy))
+                                .foregroundColor(.white)
+                                .padding()
+                                .offset(x: 20)
+                            
+                            Spacer()
+                            
+                            Button {
+                                
+                            } label: {
+                                Image(systemName: "plus.circle")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 25, height: 25)
+                                    .foregroundColor(.white)
+                                    .opacity(0.6)
+                                    .padding()
+                            }
+                            .padding(.horizontal, 20)
+                        }
+                        
+                        // MARK: 개인 메모장 박스
+                        ScrollView(.horizontal, showsIndicators: true) {
+                            HStack {
+                                ForEach(memoList, id: \.self) { memo in
+                                    VStack(alignment: .leading) {
+                                        Text("2022.6.3")
+                                            .font(.system(size: 16, weight: .medium))
+                                            .foregroundColor(Color("Button"))
+                                        Text("15:46")
+                                            .font(.system(size: 16, weight: .medium))
+                                            .foregroundColor(.gray)
+                                        Text("\(memo)")
+                                            .frame(width: 280, height: 80)
+                                            .font(.system(size: 20, weight: .semibold))
+                                            .foregroundColor(.white)
+                                            .multilineTextAlignment(.leading)
+                                            .lineLimit(3)
+                                    }
+                                    .frame(width: 340, height: 180)
+                                    .background(Color("DarkPanel").opacity(0.8))
+                                    .shadow(color: Color("Morphic2").opacity(0.8), radius: 4, x: 4, y: 4)
+                                    .shadow(color: Color("Morphic1").opacity(0.6), radius: 4, x: -4, y: -4)
+                                    .cornerRadius(30)
+                                    .padding(.horizontal, 10)
+                                }
+                            }
+                        }
+                    }
+            }
+            .attachPartialSheetToRoot()
+        }
+        .navigationTitle("길고양이 기록장")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .navigationViewStyle(.stack)
+        // MARK: 툴바 수정
+        .toolbar {
+            ToolbarItem(placement: .navigation) {
+                Image(systemName: "chevron.backward")
+                    .foregroundColor(.white)
+                    .onTapGesture {
+                        self.presentation.wrappedValue.dismiss()
+                    }
+            }
+        }
     }
 }
 

--- a/GilCat/GilCat/Sources/Screen/Note/NoteWaterView.swift
+++ b/GilCat/GilCat/Sources/Screen/Note/NoteWaterView.swift
@@ -1,0 +1,20 @@
+//
+//  NoteWaterView.swift
+//  GilCat
+//
+//  Created by KYUBO A. SHIM on 2022/06/12.
+//
+
+import SwiftUI
+
+struct NoteWaterView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct NoteWaterView_Previews: PreviewProvider {
+    static var previews: some View {
+        NoteWaterView()
+    }
+}


### PR DESCRIPTION
[PR 양식]

## 작업내용
- #17 
- 하프모달 패키지를 추가하고 기록장 뷰에 사용
- 버튼 모양으로 뉴모픽 느낌을 냈는데 분위기랑 안맞으면 빼겠습니다.
  - 위의 뉴모픽 버튼 때문에 새로운 컬러 에셋 추가했습니다.
- 노트뷰의 하위 뷰인 food, water, profile 뷰는 다음 푸쉬때 추가

## 스크린샷
<p align="left">
<img width="200" alt="" src="https://user-images.githubusercontent.com/89404664/173213628-070d7550-6b77-4662-b1a1-c9bc4efe8682.png">
<img width="200" alt="" src="https://user-images.githubusercontent.com/89404664/173213636-0ca83434-ab0b-4411-9de5-a0d728ca31b8.png">
<img width="200" alt="" src="https://user-images.githubusercontent.com/89404664/173213642-0b35474e-cb06-41e0-94b4-58626055cffb.png">
</p>

## Reference
- half modal: https://github.com/AndreaMiotto/PartialSheet




