### PR TITLE
뒤로가기 영역 통일(도피 피드백)

### DIFF
--- a/GilCat/GilCat/Sources/Screen/Note/NoteView.swift
+++ b/GilCat/GilCat/Sources/Screen/Note/NoteView.swift
@@ -59,6 +59,7 @@ struct NoteView: View {
                 ToolbarItem(placement: .navigation) {
                     Image(systemName: "xmark")
                         .frame(width: 50, height: 40, alignment: .leading)
+                        .contentShape(Rectangle())
                         .foregroundColor(.white)
                         .onTapGesture {
                             self.presentation.wrappedValue.dismiss()

--- a/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterAge.swift
+++ b/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterAge.swift
@@ -47,6 +47,7 @@ struct RegisterAge: View {
                 ToolbarItem(placement: .navigation) {
                     Image(systemName: "chevron.backward")
                         .frame(width: 50, height: 40, alignment: .leading)
+                        .contentShape(Rectangle())
                         .foregroundColor(.white)
                         .onTapGesture {
                             self.presentation.wrappedValue.dismiss()

--- a/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterAvatar.swift
+++ b/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterAvatar.swift
@@ -42,6 +42,7 @@ struct RegisterAvatar: View {
                 ToolbarItem(placement: .navigation) {
                     Image(systemName: "chevron.backward")
                         .frame(width: 50, height: 40, alignment: .leading)
+                        .contentShape(Rectangle())
                         .foregroundColor(.white)
                         .onTapGesture {
                             self.presentation.wrappedValue.dismiss()

--- a/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterCode.swift
+++ b/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterCode.swift
@@ -40,6 +40,7 @@ struct RegisterCode: View {
                 ToolbarItem(placement: .navigation) {
                     Image(systemName: "chevron.backward")
                         .frame(width: 50, height: 40, alignment: .leading)
+                        .contentShape(Rectangle())
                         .foregroundColor(.white)
                         .onTapGesture {
                             self.presentation.wrappedValue.dismiss()

--- a/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterFinish.swift
+++ b/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterFinish.swift
@@ -42,6 +42,7 @@ struct RegisterFinish: View {
                 ToolbarItem(placement: .navigation) {
                     Image(systemName: "chevron.backward")
                         .frame(width: 50, height: 40, alignment: .leading)
+                        .contentShape(Rectangle())
                         .foregroundColor(.white)
                         .onTapGesture {
                             self.presentation.wrappedValue.dismiss()

--- a/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterGender.swift
+++ b/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterGender.swift
@@ -47,6 +47,7 @@ struct RegisterGender: View {
             ToolbarItem(placement: .navigation) {
                 Image(systemName: "chevron.backward")
                     .frame(width: 50, height: 40, alignment: .leading)
+                    .contentShape(Rectangle())
                     .foregroundColor(.white)
                     .onTapGesture {
                         self.presentation.wrappedValue.dismiss()

--- a/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterName.swift
+++ b/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterName.swift
@@ -32,6 +32,7 @@ struct RegisterName: View {
             ToolbarItem(placement: .navigation) {
                 Image(systemName: "chevron.backward")
                     .frame(width: 50, height: 40, alignment: .leading)
+                    .contentShape(Rectangle())
                     .foregroundColor(.white)
                     .onTapGesture {
                         self.presentation.wrappedValue.dismiss()

--- a/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterStart.swift
+++ b/GilCat/GilCat/Sources/Screen/Registers/registerViews/RegisterStart.swift
@@ -37,6 +37,7 @@ struct RegisterStart: View {
                     ToolbarItem(placement: .navigation) {
                         Image(systemName: "chevron.backward")
                             .frame(width: 50, height: 40, alignment: .leading)
+                            .contentShape(Rectangle())
                             .foregroundColor(.white)
                             .onTapGesture {
                                 self.presentation.wrappedValue.dismiss()


### PR DESCRIPTION
## 작업내용
- 뒤로가기 영역 더확장
- 프레임 영역과 동일

## 스크린샷
<img width="352" alt="KakaoTalk_Photo_2022-06-16-22-34-37" src="https://user-images.githubusercontent.com/70618615/174081940-be9d1873-2f65-460a-8972-b4a21be9cf0e.png">

(사진상 노란색은 영역표시용도, 코드엔 지움)
